### PR TITLE
Add composer-git-hooks library

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Composer Locator](https://github.com/mindplay-dk/composer-locator) - Provides a means of locating the installation path for a given Composer package name.  
 - [PackageInfo](https://github.com/ThaDafinser/PackageInfo) - Check if a package is installed and retrieve all package informations like version, tag release date, description, ... 
 - [composer-ignore-plugin](https://github.com/lichunqiang/composer-ignore-plugin) - The composer plugin to remove useless files in vendor by yourself.
+- [composer-git-hooks](https://github.com/BrainMaestro/composer-git-hooks) - A library for easily managing git hooks in your composer config.
 
 ## Tools
 


### PR DESCRIPTION
This library is useful for projects that want to implement git hook usage while making it easy for every project member to be involved. It's primarily for adding simple git hooks like testing before pushing.