### PR TITLE
Adds phpcodesniffer-composer-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [composer-ignore-plugin](https://github.com/lichunqiang/composer-ignore-plugin) - The composer plugin to remove useless files in vendor by yourself.
 - [composer-git-hooks](https://github.com/BrainMaestro/composer-git-hooks) - A library for easily managing git hooks in your composer config.
 - [Symfony-Flex](https://github.com/symfony/flex) - Provides [recipe-based](https://github.com/symfony/recipes) installation and configuration management for Symfony packages.
+- [phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer) - Automates the configuration of custom PHP_CodeSniffer standards/sniffs via Composer
 
 ## Tools
 


### PR DESCRIPTION
Added https://github.com/DealerDirect/phpcodesniffer-composer-installer to the list.