### PR TITLE
Packagist Mirrors (cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ Private Packagist](http://www.naderman.de/slippy/slides/2017-07-14-T3DD17-Gain-c
 ### Packagist Mirrors
 
 - North America
-  - Canada - https://packagist.org
+  - Canada - [packagist.org](https://packagist.org)
 - South America
-  - Brazil - https://packagist.com.br
+  - Brazil - [packagist.com.br](https://packagist.com.br)
 - Asia
-  - Japan - https://packagist.jp
-  - China - [https://packagist.phpcomposer.com](https://pkg.phpcomposer.com)
+  - Japan - [packagist.jp](https://packagist.jp)
+  - China - [packagist.phpcomposer.com](https://pkg.phpcomposer.com)
 
 ## Composer Repositories
 

--- a/README.md
+++ b/README.md
@@ -151,15 +151,13 @@ Private Packagist](http://www.naderman.de/slippy/slides/2017-07-14-T3DD17-Gain-c
 
 ### Packagist Mirrors
 
-- Europe
-  - France https://packagist.org/ - 87.98.253.214 (ovh.net).
+- North America
+  - Canada - https://packagist.org
+- South America
+  - Brazil - https://packagist.com.br
 - Asia
-  - Japan http://packagist.jp/ - 104.28.30.100 (CloudFlare, San Fransico, USA).
-  - China https://packagist.laravel-china.org/
-  - China http://packagist.cn/ - 123.56.107.40 (Aliyun Computing; Alibaba, Hangzhou, China). (Abandoned)
-  - China http://www.phpcomposer.com/
-- USA
-  - Give http://packagist.jp/ a try.
+  - Japan - https://packagist.jp
+  - China - https://packagist.phpcomposer.com
 
 ## Composer Repositories
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Private Packagist](http://www.naderman.de/slippy/slides/2017-07-14-T3DD17-Gain-c
   - Brazil - https://packagist.com.br
 - Asia
   - Japan - https://packagist.jp
-  - China - https://packagist.phpcomposer.com
+  - China - [https://packagist.phpcomposer.com](https://pkg.phpcomposer.com)
 
 ## Composer Repositories
 


### PR DESCRIPTION
Sorry for all changes, is the same context and a lot of information is outdated:

- Removed all domain's abadoned (http://packagist.cn/ and https://packagist.laravel-china.org/)
- Fixed real location for packagist.org (Canada)
- Removed IP (because this change over the time)
- Added new mirror for South America (yey!)