### PR TITLE
Add Cloudsmith (a Packagist-compatible service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Firegento](http://packages.firegento.com/) - A Composer Repository providing Magento Modules.
 - [Drupal Packagist](https://www.drupal.org/node/2822344) - Composer repositories for Drupal 7 and 8 core, modules, and themes.
 - [Satis Server](https://github.com/lukaszlach/satis-server) - This docker container provides a Satis Server and enables you to run a private, self-hosted Composer repository with support for Git, Mercurial, and Subversion, HTTP API, HTTPs support, webhook handler and scheduled builds.
+- [Cloudsmith](https://cloudsmith.io) - A fully managed package management SaaS with PHP/Composer support (and many others).
 
 ## GUI 
 


### PR DESCRIPTION
Hi! This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for PHP/Composer (and many other package formats, such as Python/Ruby), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc. Thank you. :-)

*Full disclosure:* I work at Cloudsmith.