### PR TITLE
Add Release Belt (Composer repository implementation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ About metadata mirrors: https://packagist.org/mirrors
 
 - [ToranProxy](https://toranproxy.com/) (deprecated) - In addition to providing a composer repository ToranProxy acts as a proxy server for Packagist and GitHub.
 
+### Release Belt
+
+- [Release Belt](https://github.com/Rarst/release-belt) - Self–hosted Composer repository implementation to quickly integrate ZIP files of third party non–Composer releases.
+
 ---
 
 ## License


### PR DESCRIPTION
> Release Belt is a Composer repository, which serves to quickly integrate third party non–Composer releases into Composer workflow. Once Release Belt is installed and you upload your zip files with their respected version number, Release Belt does the rest.
>
> https://github.com/Rarst/release-belt

I am the developer of Release Belt for disclosure.