### PR TITLE
Add "Composer Preload" plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Foxy](https://github.com/fxpio/foxy) - Composer plugin that executes npm/yarn packages installation operations when composer package is installed or updated.
 - [NodeJS-Installer](https://github.com/thecodingmachine/nodejs-installer) - Downloads and installs NodeJS and npm as composer package. 
 - [Imposter-Plugin](https://github.com/typisttech/imposter-plugin) - Wrapping all composer vendor packages inside your own namespace. Intended for WordPress plugins.
+- [Composer Preload](https://github.com/Ayesh/Composer-Preload) - Plugin to generate a `vendor/preload.php` file to warm up opcache
 
 ## Tools
 


### PR DESCRIPTION
Hi Jens,
Please consider adding "Composer Preload" plugin to the list. 

This is a shameless self plug, but I genuinely believe this plugin serves a useful purpose. It adds a new "composer preload" command that, when run, creates a `vendor/preload.php` file that can cache a configurable list PHP files to opcache, speeding up execution of the app. 

This can come really handy when phone 7.4 comes with Preload RFC implemented. 

Thanks,
Ayesh. 