### PR TITLE
Add composer-plugin-patchset to the plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Composer-Patches-Plugin](https://github.com/netresearch/composer-patches-plugin) - Enables you to provide patches for any package from any package. When the dependency is fetched, the patch is applied on top.
 - [Composer-Patches](https://github.com/cweagans/composer-patches) - The plugin applies a patch from a local or remote file to any required package.
 - [Composer-Patches](https://github.com/vaimo/composer-patches) - Applies a patch from a local or remote file to any package that is part of a given composer project.
+- [Composer-Patchset](https://github.com/creativestyle/composer-plugin-patchset) - Automatically fetch, update and apply patches to any composer package with a twist - store the patchset as a composer package itself.
 - [Composer-Plugin-QA](https://github.com/Webysther/composer-plugin-qa) - Comprehensive Plugin for composer to execute PHP Quality assurance Tools.
 - [Composer-Cleanup-Plugin](https://github.com/barryvdh/composer-cleanup-plugin) - Removes tests & documentation folders from the vendor dir.
 - [Composer-Cleaner](https://github.com/dg/composer-cleaner) - The tool removes unnecessary files and directories from the vendor directory.


### PR DESCRIPTION
Even though there's already a lot of patching plugins listed I think this one has a unique approach - among others it allows easy distribution of whole patchsets as composer packages. Additionally it's got a functional test suite.

Disclaimer: I'm the author.