### PR TITLE
Add link to Composer-Downloads-Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Composer Registry Manager](https://github.com/slince/composer-registry-manager) - Enables you to switch between different composer repositories.
 - [Production-Dependencies-Guard](https://github.com/kalessil/production-dependencies-guard) - Prevents development packages from being added into require and getting into production environment.
 - [Composer Exclusive Install](https://github.com/erickskrauch/composer-exclusive-install) - Prevents more than one install or update operation at a time.
+- [Composer-Downloads-Plugin](https://github.com/civicrm/composer-downloads-plugin) - Lightweight mechanism to download external resources (ZIP/TAR files) with only a `url` and `path`.
 
 ## Tools
 


### PR DESCRIPTION
This plugin is handy for package authors who need to include an external asset and who need to be compatible with a diverse range of root-projects.

Disclosure: I wrote the updated version of this plugin.