### PR TITLE
Adds node-composer to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Composer-Warmup](https://github.com/jderusse/composer-warmup) - The plugin adds the command `warmup-opcode` to Composer, which triggers the compilation of all PHP files discovered in your project into the Opcache.
 - [Foxy](https://github.com/fxpio/foxy) - Composer plugin that executes npm/yarn packages installation operations, when composer package is installed or updated.
 - [NodeJS-Installer](https://github.com/thecodingmachine/nodejs-installer) - Downloads and installs NodeJS and npm as composer package.
+- [node-composer](https://github.com/mariusbuescher/node-composer) - Another NodeJS, npm and yarn installer as composer package.
 - [Imposter-Plugin](https://github.com/typisttech/imposter-plugin) - Wrapping all composer vendor packages inside your own namespace. Intended for WordPress plugins.
 - [Composer Preload](https://github.com/Ayesh/Composer-Preload) - The plugin generates a `vendor/preload.php` file to warm up the Opcache.
 - [PHP Inc](https://github.com/krakphp/php-inc) - Automatically includes files for autoload and autoload-dev to facilitate using functions and grouped definitions within composer loaded applications.


### PR DESCRIPTION
[node-composer](https://github.com/mariusbuescher/node-composer) is another good composer plugin to install NodeJS as dependency. I think it should be included in this list.