### PR TITLE
Add composer-compile-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Composer-Downloads-Plugin](https://github.com/civicrm/composer-downloads-plugin) - Lightweight mechanism to download external resources (ZIP/TAR files) with only a `url` and `path`.
 - [Private-Composer-Installer](https://github.com/ffraenz/private-composer-installer) - Install helper outsourcing sensitive keys from the package URL into environment variables.
 - [CycloneDX-PHP-Composer](https://github.com/CycloneDX/cyclonedx-php-composer) - Creates a [CycloneDX](https://cyclonedx.org/) "Software Bill-of-Materials" (SBOM) for the dependencies of a project. The SBOM enables dependency monitoring and risk analysis by [OWASP DependencyTrack](https://dependencytrack.org/).
+- [Composer-Compile-Plugin](https://github.com/civicrm/composer-compile-plugin) - Allow PHP libraries to define simple, freeform compilation tasks. Support post-install hooks in any package.
 
 ## Tools
 


### PR DESCRIPTION
[composer-compile-plugin](https://github.com/civicrm/composer-compile-plugin) allows library packages to define their own compilation steps (similar to post-install hooks).  Adds a permission/whitelist mechanism to prompt downstream developers for permission before executing new compilation tasks.