### PR TITLE
Add composer.guru- a semver range checker- to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 
 - [Jordi Boggiano (seldaek)](https://seld.be/)
 - [Nils Adermann (naderman)](https://naderman.de/)
-- [Composer: Part 1 - What & Why](http://blog.nelm.io/2011/12/composer-part-1-what-why/)
-- [Composer: Part 2 - Impact](http://blog.nelm.io/2011/12/composer-part-2-impact/)
 - [Composer Stability Flags](https://igor.io/2013/02/07/composer-stability-flags.html)
 - [Composer Versioning](https://igor.io/2013/01/07/composer-versioning.html)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Composer PreferLowest Checker](https://github.com/dereuromark/composer-prefer-lowest) - Strictly compare the specified minimum versions of your composer.json with the ones actually used by the prefer-lowest composer update command option.
 - [Bramus/Composer-Autocomplete](https://github.com/bramus/composer-autocomplete) - A Bash/Shell autocompletion script for Composer.
 - [Composer/Xdebug-Handler](https://github.com/composer/xdebug-handler) - Helps you to restart a CLI process without loading the xdebug extension.
+- [Composer Semver Range Checker](https://gitlab.com/MattyRad/composer.guru) - A tool to help check the satisfiable ranges of a composer constraint.
 
 ## Scripts
 
@@ -216,7 +217,7 @@ About metadata mirrors: https://packagist.org/mirrors
 ### Repman
 
 - [repman.io](https://repman.io) & [repman-io/repman](https://github.com/repman-io/repman) - A Private PHP Package Repository Manager & Packagist Proxy.
-- [repman-io/composer-plugin](https://github.com/repman-io/composer-plugin) - This plugin enables downloading via Repman by adding a distribution mirror URL for all your dependencies (without need to update the `composer.lock` file). 
+- [repman-io/composer-plugin](https://github.com/repman-io/composer-plugin) - This plugin enables downloading via Repman by adding a distribution mirror URL for all your dependencies (without need to update the `composer.lock` file).
 
 ## Packagist-compatible repositories
 


### PR DESCRIPTION
Hi. I just made [a tool](https://composer.guru) for myself and my workplace to generate satisfiable ranges from a semver constraint. It's [open source](https://gitlab.com/MattyRad/composer.guru).

There's a similar tool located at [semver.mwl.be/](https://semver.mwl.be/), but it's not quite practical for me since it requires a public facing repository to compare refs against. [semver-check](https://jubianchi.github.io/semver-check/#/) is almost the same tool, but produces slightly different ranges than composer. So I made this (pretty simple) tool which just taps in to the functions made available by the [composer/semver](https://github.com/composer/semver) repository.