### PR TITLE
Add composer-link plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You might also like [awesome-php](https://github.com/ziadoz/awesome-php).
 - [Private-Composer-Installer](https://github.com/ffraenz/private-composer-installer) - Install helper outsourcing sensitive keys from the package URL into environment variables.
 - [CycloneDX-PHP-Composer](https://github.com/CycloneDX/cyclonedx-php-composer) - Creates a [CycloneDX](https://cyclonedx.org/) "Software Bill-of-Materials" (SBOM) for the dependencies of a project. The SBOM enables dependency monitoring and risk analysis by [OWASP DependencyTrack](https://dependencytrack.org/).
 - [Composer-Compile-Plugin](https://github.com/civicrm/composer-compile-plugin) - Allow PHP libraries to define simple, freeform compilation tasks. Support post-install hooks in any package.
+- [Composer-link](https://github.com/SanderSander/composer-link) - Adds the ability to link local packages for development into composer
 
 ## Tools
 


### PR DESCRIPTION
Adds ability to link local packages in composer for development.

This plugin won't alter your composer.json or composer.lock file, while maintaining the composer abilities to manage/upgrade your packages.

https://github.com/SanderSander/composer-link