### PR TITLE
Add RepoFlow under Packagist-compatible repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ About metadata mirrors: https://packagist.org/mirrors
 - [Cloudsmith](https://cloudsmith.com/) - A fully managed package management SaaS with PHP/Composer support (and many others).
 - [Release Belt](https://github.com/Rarst/release-belt) - Self–hosted Composer repository implementation to quickly integrate ZIP files of third party non–Composer releases.
 - [Packeton](https://github.com/vtsykun/packeton) - Private self-hosted Composer repository for vendors. Fork of packagist with adding support for authorization, customer users, groups, webhooks.
+- [RepoFlow](https://www.repoflow.io) - Simple and fast platform for hosting private Composer registries. Also supports Docker, npm, PyPI, Maven, and RubyGems. Offers free options for both cloud and self-hosted setups.
 
 ### Satis
 


### PR DESCRIPTION
RepoFlow is a package hosting platform with Composer registry support. Added under the Packagist-compatible repositories section as per contribution guidelines.

Public documentation: https://docs.repoflow.io
Official website: https://www.repoflow.io